### PR TITLE
feat(rules): omit arrow function parens unless they are necessary

### DIFF
--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -12,9 +12,6 @@ module.exports = {
     'arrow-parens': [
       'error',
       'as-needed',
-      {
-        requireForBlockBody: true,
-      },
     ],
     'arrow-spacing': [
       'error',


### PR DESCRIPTION
Remove `requireForBlockBody` option of `arrow-parens` rule.

BREAKING CHANGE: previously, only arrow functions consisting of a single
expression were allowed to omit parentheses around the parameter list
(and required to, if there's only one parameter in the list).  After
this change, the parens are only allowed when they are required
syntactically.

Before:

```js
const f = x => x;

const g = (x, y) => x + y;

const h = (x) => {
  console.log(x);
};

const i = (x, f) => {
  f(x);
};
```

After:

```js
// Not affected
const f = x => x;

// Not affected
const g = (x, y) => x + y;

// AFFECTED
const h = x => {
  console.log(x);
};

// Not affected
const i = (x, f) => {
  f(x);
};
```

This rule is fixable via `eslint --fix`.

Refs: https://github.com/metarhia/Metarhia/issues/22

/cc @tshemsedinov @lundibundi @nechaido @belochub @alinkedd @JuliaGerasymenko 