### PR TITLE
feat(rules): add consistent-return rule

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -23,5 +23,8 @@ module.exports = {
       'multi-line',
       'consistent',
     ],
+    'consistent-return': [
+      'error',
+    ],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: before this change, it was possible to have a function
that used the `return` statement with a value only in some of its
execution paths. This rule enforces function to explicitly return a
value in every execution path if at least one execution path returns a
value.

Before:

```js
function doSomething(condition) {
    if (condition) {
        return true;
    } else {
        return;
    }
}
```

After:

```js
function doSomething(condition) {
    if (condition) {
        return true;
    } else {
        return false;
    }
}

// or

function doSomething(condition) {
    if (condition) {
        return true;
    }
    return false;
}
```