### PR TITLE
feat(rules): enforce curly braces on multiline blocks

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -18,5 +18,10 @@ module.exports = {
     'no-useless-concat': [
       'error',
     ],
+    'curly': [
+      'error',
+      'multi-line',
+      'consistent',
+    ],
   },
 };


### PR DESCRIPTION
Add 'curly' rule with 'multi-line' and 'consistent' options.

BREAKING CHANGE: before this change, it was allowed to avoid the use of
block statements (curly braces) with `if`, `else`, `for`, `while`, and
`do`, when there is only one statement in the block. After this change,
omitting the curly braces is only allowed when the statement is on the
same line as `if`, `else if`, `else`, `for`, `while`, or `do`. Also,
this change enforces consistency in the usage of curly braces for `if`,
`else if` and `else` chains.

Before:

```js
if (foo)
  bar();

if (x) a();
else {
  b();
  c();
}
```

After:

```js
if (foo) bar();

// or

if (foo) {
  bar();
}

if (x) {
  a();
} else {
  b();
  c();
}
```

Some of the problems reported by this rule can be fixed via
`eslint --fix`.