### PR TITLE
feat(rules): add no-return-assign rule

### DIFF
--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -11,5 +11,8 @@ module.exports = {
         checkLoops: false,
       },
     ],
+    'no-return-assign': [
+      'error',
+    ],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: before, it was possible to use assignment operators in
a return statement without using parentheses, which could lead to some
mistakes, where assignment operators are used in place of the comparison
operators.

Before:

```js
function doSomething() {
  return foo = bar + 2;
}
```

After:

```js
function doSomething() {
  return foo === bar + 2;
}

// or

function doSomething() {
  return (foo = bar + 2);
}
```