### PR TITLE
feat(rules): remove implicit-arrow-linebreak rule

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -46,10 +46,6 @@ module.exports = {
     'eol-last': [
       'error',
     ],
-    'implicit-arrow-linebreak': [
-      'error',
-      'beside',
-    ],
     'func-call-spacing': [
       'error',
       'never',


### PR DESCRIPTION
This reverts commit 75748ffdf7a0b6e796631221b8f1f8713bc178e5.

After this change, following code will become valid:

```js
const fn = () =>
  doSomething();
```