### PR TITLE
feat(rules): add no-extra-parens rule

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -166,5 +166,14 @@ module.exports = {
         },
       },
     ],
+    'no-extra-parens': [
+      'error',
+      'all',
+      {
+        returnAssign: false,
+        nestedBinaryExpressions: false,
+        enforceForArrowConditionals: false,
+      },
+    ],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: with this change it is allowed to use parentheses
only where they are necessary, except for arrow conditionals (to avoid
conflicts with no-confusing-arrow rule), return assignments (to avoid
conflicts with no-return-assign rule) and nested binary expressions
(where parentheses can be used for clarity).

Before:

```js
a = (b * c);

typeof (a);

const fn = () => (
  doSomething()
);
```

After:

```js
a = b * c;

typeof a;

const fn = () => doSomething();
```