### PR TITLE
feat(rules): enable allowTemplateLiterals option for quotes rule

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -125,6 +125,9 @@ module.exports = {
     'quotes': [
       'error',
       'single',
+      {
+        allowTemplateLiterals: true,
+      },
     ],
     'semi': [
       'error',


### PR DESCRIPTION
This makes it possible to use template literals as well as single quotes for strings.