### PR TITLE
feat(rules): change space-before-function-paren for async functions

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -100,7 +100,14 @@ module.exports = {
       },
     ],
     'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'never',
+        named: 'never',
+        asyncArrow: 'always',
+      },
+    ],
     'space-in-parens': ['error', 'never'],
     'space-infix-ops': ['error'],
     'space-unary-ops': [


### PR DESCRIPTION
This changes space-before-function-paren rule to always require space
for async functions.

BREAKING CHANGE: with this change it is an error to not have a space
before function parentheses in an async function declaration.

Before:

```js
const a = async() => {};
```

After:

```js
const a = async () => {};
```