### PR TITLE
feat(rules): disallow unnecessary return await

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -9,5 +9,6 @@ module.exports = {
     'no-useless-concat': ['error'],
     curly: ['error', 'multi-line', 'consistent'],
     'consistent-return': ['error'],
+    'no-return-await': ['error'],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: with this it is an error to use return await in an
async function where it doesn't bring any benefits. Note that separate
await and then return or return await inside of the try-catch block are
still allowed.

This is an error:

```js
async function foo() {
  return await bar();
}
```

These are not:

```js
async function foo() {
  await bar();
  return;
}
```

```js
async function foo() {
  try {
    return await bar();
  } catch (e) {}
}
```