### PR TITLE
Update consistent-return rule

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -8,7 +8,7 @@ module.exports = {
     'no-unmodified-loop-condition': ['error'],
     'no-useless-concat': ['error'],
     curly: ['error', 'multi-line', 'consistent'],
-    'consistent-return': ['error'],
+    "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }],
     'no-return-await': ['error'],
   },
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -8,7 +8,7 @@ module.exports = {
     'no-unmodified-loop-condition': ['error'],
     'no-useless-concat': ['error'],
     curly: ['error', 'multi-line', 'consistent'],
-    "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }],
+    "consistent-return": ['error', { 'treatUndefinedAsUnspecified': true }],
     'no-return-await': ['error'],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: Before this change, the `consistent-return` rule allowed functions to have a `return` statement with an implicit `undefined` value in some execution paths. However, with the new configuration that includes "treatUndefinedAsUnspecified": true, the rule enforces explicit return values in all execution paths.

Before:
```javascript
const foo = (callback) => {
  if (callback) {
    callback();
    return;
  }
  // ...code...
};
```
After:
```javascript
const foo = (callback) => {
  if (callback) return void callback();
  // ...code...
};
```