### PR TITLE
feat: Added 'no-nested-ternary' rule as error to the stylistic-issues

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -80,6 +80,7 @@ module.exports = {
     'no-lonely-if': ['error'],
     'no-trailing-spaces': ['error'],
     'no-unneeded-ternary': ['error'],
+    'no-nested-ternary': ['error'],
     'no-whitespace-before-property': ['error'],
     'object-curly-spacing': ['error', 'always'],
     'operator-assignment': ['error', 'always'],


### PR DESCRIPTION

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
