### PR TITLE
Add more global names

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ const configMetarhia = {
     sourceType: 'commonjs',
     globals: {
       BigInt: true,
+      AbortController: true,
+      AbortSignal: true,
+      DOMException: true,
+      URLSearchParams: true,
+      fetch: true,
       console: true,
       process: true,
       Buffer: true,


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
